### PR TITLE
Change coffee command to make build work

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -121,7 +121,8 @@ packager =
     exec "cat #{src.join ' '} > #{dest}", callback
 
   concat_coffee: (src, dest, callback) ->
-    exec "coffee -jp #{src.join ' '} > #{dest}", callback
+    console.log("coffee -jp #{src.join ' '} > #{dest}")
+    exec "coffee --print --join --compile #{src.join ' '} > #{dest}", callback
 
   compress: (src, type, callback) ->
     yc = require 'yui-compressor'


### PR DESCRIPTION
The coffee command wasn't actually building anything
changes the switches to make it actually compile

So as far as I can tell the build coffe command in the cake file was just joining the files, and printing them, but the files weren't being compiles so yui-compressor couldn't act on them. I fixed that. 
