### PR TITLE
Support for new authtoken format

### DIFF
--- a/src/plugin/auth.coffee
+++ b/src/plugin/auth.coffee
@@ -30,6 +30,59 @@ createDateFromISO8601 = (string) ->
   date.setTime(Number(time))
   date
 
+base64Decode = (data) ->
+  if atob?
+    # Gecko and Webkit provide native code for this
+    atob(data)
+  else
+    # Adapted from MIT/BSD licensed code at http://phpjs.org/functions/base64_decode
+    # version 1109.2015
+    b64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/="
+    i = 0
+    ac = 0
+    dec = ""
+    tmp_arr = []
+
+    if not data
+      return data
+
+    data += ''
+
+    while i < data.length
+      # unpack four hexets into three octets using index points in b64
+      h1 = b64.indexOf(data.charAt(i++))
+      h2 = b64.indexOf(data.charAt(i++))
+      h3 = b64.indexOf(data.charAt(i++))
+      h4 = b64.indexOf(data.charAt(i++))
+
+      bits = h1 << 18 | h2 << 12 | h3 << 6 | h4
+
+      o1 = bits >> 16 & 0xff
+      o2 = bits >> 8 & 0xff
+      o3 = bits & 0xff
+
+      if h3 == 64
+        tmp_arr[ac++] = String.fromCharCode(o1)
+      else if h4 == 64
+        tmp_arr[ac++] = String.fromCharCode(o1, o2)
+      else
+        tmp_arr[ac++] = String.fromCharCode(o1, o2, o3)
+
+    tmp_arr.join('')
+
+base64UrlDecode = (data) ->
+  m = data.length % 4
+  if m != 0
+    for i in [0...4 - m]
+      data += '='
+  data = data.replace(/-/g, '+')
+  data = data.replace(/_/g, '/')
+  base64Decode(data)
+
+parseToken = (token) ->
+  [head, payload, sig] = token.split('.')
+  JSON.parse(base64UrlDecode(payload))
+
 # Public: Supports the Store plugin by providing Authentication headers.
 class Annotator.Plugin.Auth extends Annotator.Plugin
   # User options that can be provided.
@@ -105,17 +158,13 @@ class Annotator.Plugin.Auth extends Annotator.Plugin
   #
   # Examples
   #
-  #   auth.setToken('{
-  #     authTokenIssueTime: "2002-03-15T15:02:02Z",
-  #     authTokenTTL: 86400,
-  #     consumerKey: "unique-string"
-  #   }.AkOV6g.SKQMC7ybClqdLR2Wjl-JhUFzasM')
+  #   auth.setToken('eyJh...9jQ3I')
   #
   # Returns nothing.
   setToken: (token) ->
     @token = token
     # Parse the token without verifying its authenticity:
-    @_unsafeToken = JSON.parse(token.split('.')[0...-2].join())
+    @_unsafeToken = parseToken(token)
 
     if this.haveValidToken()
       if @options.autoFetch
@@ -145,8 +194,8 @@ class Annotator.Plugin.Auth extends Annotator.Plugin
   # Returns true if the token is valid.
   haveValidToken: () ->
     allFields = @_unsafeToken &&
-                @_unsafeToken.authTokenIssueTime &&
-                @_unsafeToken.authTokenTTL &&
+                @_unsafeToken.issuedAt &&
+                @_unsafeToken.ttl &&
                 @_unsafeToken.consumerKey
 
     allFields && this.timeToExpiry() > 0
@@ -156,9 +205,9 @@ class Annotator.Plugin.Auth extends Annotator.Plugin
   # Returns Number of seconds until token expires.
   timeToExpiry: ->
     now = new Date().getTime() / 1000
-    issue = createDateFromISO8601(@_unsafeToken.authTokenIssueTime).getTime() / 1000
+    issue = createDateFromISO8601(@_unsafeToken.issuedAt).getTime() / 1000
 
-    expiry = issue + @_unsafeToken.authTokenTTL
+    expiry = issue + @_unsafeToken.ttl
     timeToExpiry = expiry - now
 
     if (timeToExpiry > 0) then timeToExpiry else 0

--- a/test/spec/plugin/auth_spec.coffee
+++ b/test/spec/plugin/auth_spec.coffee
@@ -16,8 +16,8 @@ describe 'Annotator.Plugin.Auth', ->
   beforeEach ->
     validToken = JSON.stringify({
       consumerKey: "key"
-      authTokenIssueTime: new Date().toISO8601String()
-      authTokenTTL: 300
+      issuedAt: new Date().toISO8601String()
+      ttl: 300
       userId: "testUser"
     }) + ".timestamp.signature"
 
@@ -48,17 +48,17 @@ describe 'Annotator.Plugin.Auth', ->
       delete mock.auth._unsafeToken.consumerKey
       expect(mock.auth.haveValidToken()).toBeFalsy()
 
-    it "returns false when the current token is missing an authTokenIssueTime", ->
-      delete mock.auth._unsafeToken.authTokenIssueTime
+    it "returns false when the current token is missing an issuedAt", ->
+      delete mock.auth._unsafeToken.issuedAt
       expect(mock.auth.haveValidToken()).toBeFalsy()
 
-    it "returns false when the current token is missing an authTokenTTL", ->
-      delete mock.auth._unsafeToken.authTokenTTL
+    it "returns false when the current token is missing a ttl", ->
+      delete mock.auth._unsafeToken.ttl
       expect(mock.auth.haveValidToken()).toBeFalsy()
 
     it "returns false when the current token expires in the past", ->
-      mock.auth._unsafeToken.authTokenTTL = 0
+      mock.auth._unsafeToken.ttl = 0
       expect(mock.auth.haveValidToken()).toBeFalsy()
-      mock.auth._unsafeToken.authTokenTTL = 86400
-      mock.auth._unsafeToken.authTokenIssueTime = "1970-01-01T00:00"
+      mock.auth._unsafeToken.ttl = 86400
+      mock.auth._unsafeToken.issuedAt = "1970-01-01T00:00"
       expect(mock.auth.haveValidToken()).toBeFalsy()


### PR DESCRIPTION
For details see okfn/annotator-store#38. There remains a question as to whether to use JSON Web Tokens or not -- please review and comment on the referenced `annotator-store` pull request.
