### PR TITLE
need to dedupe and update existing annotations when adding more annotati...

### DIFF
--- a/src/plugin/store.coffee
+++ b/src/plugin/store.coffee
@@ -259,8 +259,21 @@ class Annotator.Plugin.Store extends Annotator.Plugin
   #
   # Returns nothing.
   _onLoadAnnotations: (data=[]) =>
-    @annotations = @annotations.concat(data)
-    @annotator.loadAnnotations(data.slice()) # Clone array
+
+    annotationMap = {}
+    for a in @annotations
+      annotationMap[a.id] = a
+
+    newData = []
+    for a in data
+      if annotationMap[a.id]
+        annotation = annotationMap[a.id]
+        this.updateAnnotation annotation, a
+      else
+        newData.push(a)
+
+    @annotations = @annotations.concat(newData)
+    @annotator.loadAnnotations(newData.slice()) # Clone array
 
   # Public: Performs the same task as Store.#loadAnnotations() but calls the
   # 'search' URI with an optional query string.

--- a/test/spec/plugin/store_spec.coffee
+++ b/test/spec/plugin/store_spec.coffee
@@ -221,11 +221,11 @@ describe "Annotator.Plugin.Store", ->
       assert.notStrictEqual(store.annotator.loadAnnotations.lastCall.args[0], data)
       assert.deepEqual(store.annotator.loadAnnotations.lastCall.args[0], data)
 
-    it "should concatenate new annotations when called a second time", ->
-      data = [1,2,3];
-      data2 = [4,5,6];
-      dataAll = data.concat(data2);
-      store._onLoadAnnotations(data)
+    it "should add, dedupe and update annotations when called for the 2nd time", ->
+      data1 = [{id: 1}, {id: 2}]
+      data2 = [{id: 1, foo: "bar"}, {id: 3}]
+      dataAll = [{id: 1, foo: "bar"}, {id: 2}, {id: 3}]
+      store._onLoadAnnotations(data1)
       store._onLoadAnnotations(data2)
       assert.deepEqual(store.annotations, dataAll)
 


### PR DESCRIPTION
this bit of functionality is important for the cross-format-annotation to work properly. we don't want to display the same annotation more than once when querying by related uris. see related pull request for some discussion of this https://github.com/okfn/annotator/pull/208
