### PR TITLE
Allow select as an element type for `Annotator.Editor.addField()`

### DIFF
--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -177,8 +177,8 @@ class Annotator.Editor extends Annotator.Widget
   #           id     - A unique id for the form element will also be set as the
   #                    "for" attrubute of a label if there is one. Defaults to
   #                    a timestamp. (default: "annotator-field-{timestamp}")
-  #           type   - Input type String. One of "input", "textarea", "checkbox"
-  #                    (default: "input")
+  #           type   - Input type String. One of "input", "textarea",
+  #                    "checkbox", "select" (default: "input")
   #           label  - Label to display either in a label Element or as place-
   #                    holder text depending on the type. (default: "")
   #           load   - Callback Function called when the editor is loaded with a
@@ -241,6 +241,7 @@ class Annotator.Editor extends Annotator.Widget
     switch (field.type)
       when 'textarea'          then input = $('<textarea />')
       when 'input', 'checkbox' then input = $('<input />')
+      when 'select' then input = $('<select />')
 
     element.append(input);
 


### PR DESCRIPTION
This is useful for a custom plugin I use which swaps the tags plugin's input element for a select element.  To make this plugin work, I had to patch editor.coffee.
