### PR TITLE
look for prism and eprints metadata 

### DIFF
--- a/src/plugin/document.coffee
+++ b/src/plugin/document.coffee
@@ -35,9 +35,10 @@ class Annotator.Plugin.Document extends Annotator.Plugin
     # TODO: look for microdata/rdfa?
     this._getHighwire()
     this._getDublinCore()
-    this._getOpenGraph()
+    this._getFacebook()
     this._getEprints()
     this._getPrism()
+    this._getTwitter()
     this._getFavicon()
 
     # extract out/normalize some things
@@ -47,49 +48,30 @@ class Annotator.Plugin.Document extends Annotator.Plugin
     return @metadata
 
   _getHighwire: =>
-    m = {}
-    for meta in $("meta")
-      name = $(meta).prop("name")
-      content = $(meta).prop("content")
-      match = name.match(/^citation_(.+)$/)
-      if match
-        name = match[1]
-        if m[name]
-          m[name].push(content)
-        else
-          m[name] = [content]
-    return @metadata.highwire = m
+    return @metadata.highwire = this._getMetaTags("citation", "name", "_")
 
-  _getOpenGraph: =>
-    @metadata.og = {}
-    for meta in $("meta")
-      property = $(meta).attr("property")
-      content = $(meta).prop("content")
-      if property
-        match = property.match(/^og:(.+)$/)
-        if match
-          n = match[1]
-          if @metadata.og[n]
-            @metadata.og[n].push(content)
-          else
-            @metadata.og[n] = [content]
+  _getFacebook: =>
+    return @metadata.facebook = this._getMetaTags("og", "property", ":")
+
+  _getTwitter: =>
+    return @metadata.twitter = this._getMetaTags("twitter", "name", ":")
 
   _getDublinCore: =>
-    return @metadata.dc = this._getMetaTags("dc")
+    return @metadata.dc = this._getMetaTags("dc", "name", ".")
 
   _getPrism: =>
-    return @metadata.prism = this._getMetaTags("prism")
+    return @metadata.prism = this._getMetaTags("prism", "name", ".")
 
   _getEprints: =>
-    return @metadata.eprints = this._getMetaTags("eprints")
+    return @metadata.eprints = this._getMetaTags("eprints", "name", ".")
 
-  _getMetaTags: (prefix) =>
+  _getMetaTags: (prefix, attribute, delimiter) =>
     tags = {}
     for meta in $("meta")
-      name = $(meta).prop("name")
+      name = $(meta).attr(attribute)
       content = $(meta).prop("content")
       if name
-        match = name.match(RegExp("^#{prefix}\.(.+)$", "i"))
+        match = name.match(RegExp("^#{prefix}#{delimiter}(.+)$", "i"))
         if match
           n = match[1]
           if tags[n]
@@ -98,7 +80,6 @@ class Annotator.Plugin.Document extends Annotator.Plugin
             tags[n] = [content]
     return tags
 
-
   _getTitle: =>
     if @metadata.highwire.title
       @metadata.title = @metadata.highwire.title[0]
@@ -106,6 +87,10 @@ class Annotator.Plugin.Document extends Annotator.Plugin
       @metadata.title = @metadata.eprints.title
     else if @metadata.prism.title
       @metadata.title = @metadata.prism.title
+    else if @metadata.facebook.title
+      @metadata.title = @metadata.facebook.title
+    else if @metadata.twitter.title
+      @metadata.title = @metadata.twitter.title
     else if @metadata.dc.title
       @metadata.title = @metadata.dc.title
     else

--- a/test/spec/plugin/document_spec.coffee
+++ b/test/spec/plugin/document_spec.coffee
@@ -29,6 +29,7 @@ describe 'Annotator.Plugin.Document', ->
     head.append('<meta name="dc.identifier" content="isbn:123456789">')
     head.append('<meta name="DC.type" content="Article">')
     head.append('<meta property="og:url" content="http://example.com">')
+    head.append('<meta name="twitter:site" content="@okfn">')
     head.append('<link rel="icon" href="http://example.com/images/icon.ico"></link>')
     head.append('<meta name="eprints.title" content="Computer Lib / Dream Machines">')
     head.append('<meta name="prism.title" content="Literary Machines">')
@@ -75,9 +76,9 @@ describe 'Annotator.Plugin.Document', ->
       assert.deepEqual(annotation.document.dc.identifier, ["doi:10.1175/JCLI-D-11-00015.1", "isbn:123456789"])
       assert.deepEqual(annotation.document.dc.type, ["Article"])
 
-    it 'should have opengraph metadata', ->
-      assert.ok(annotation.document.og)
-      assert.deepEqual(annotation.document.og.url, ["http://example.com"])
+    it 'should have facebook metadata', ->
+      assert.ok(annotation.document.facebook)
+      assert.deepEqual(annotation.document.facebook.url, ["http://example.com"])
 
     it 'should have eprints metadata', ->
       assert.ok(annotation.document.eprints)
@@ -86,7 +87,11 @@ describe 'Annotator.Plugin.Document', ->
     it 'should have prism metadata', ->
       assert.ok(annotation.document.prism)
       assert.deepEqual(annotation.document.prism.title, ['Literary Machines'])
-     
+
+     it 'should have twitter card metadata', ->
+      assert.ok(annotation.document.twitter)
+      assert.deepEqual(annotation.document.twitter.site, ['@okfn'])
+    
     it 'should have unique uris', ->
       uris = annotator.plugins.Document.uris()
       assert.equal(uris.length, 5)


### PR DESCRIPTION
The Document plugin will now look for PRISM and Eprints metadata similar to what Google Scholar [does](http://www.google.com/intl/en/scholar/inclusion.html#indexing). This is in addition to the Highwire Press tags that it was already looking for. I renamed the 'scholar' metadata key to 'highwire' since it is more explicit that way. Google Scholar doesn't really have its own metadata format, and "citation_*" is from Highwire Press. 

The commit message should've mentioned that this fixes #212 
