### PR TITLE
Document 'make develop' with the rest of the make rules

### DIFF
--- a/HACKING.markdown
+++ b/HACKING.markdown
@@ -44,6 +44,7 @@ Building the packaged version of Annotator involves running the appropriate
 `make` task. For example:
 
     $ make                     # build everything
+    $ make develop             # converts CoffeeScript to JavaScript by calling ./tools/build
     $ make bookmarklet         # build the bookmarklet
     $ make annotator plugins   # build annotator and individual plugin files.
 


### PR DESCRIPTION
Although it's a one-line wrapper, people are likely to look next to the
other make rules for this.

This make rule also does not require mapcat.
