### PR TITLE
added SHELL declaration so that make is able to find mapcat

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-REPORTER=dot
+REPORTER=spec
 
 default: all
 

--- a/pkg/Makefile
+++ b/pkg/Makefile
@@ -1,6 +1,7 @@
 vpath %.coffee ../src
 
-PATH:=$(shell npm bin):$(PATH)
+SHELL := /bin/bash
+PATH := $(shell npm bin):$(PATH)
 
 ANNOTATOR=\
 	xpath.coffee \
@@ -17,6 +18,7 @@ ANNOTATOR=\
 PLUGINS=\
 	plugin/annotateitpermissions.coffee \
 	plugin/auth.coffee \
+	plugin/document.coffee \
 	plugin/filter.coffee \
 	plugin/kitchensink.coffee \
 	plugin/markdown.coffee \


### PR DESCRIPTION
Prior to adding the SHELL declaration make was aborting because it couldn't find mapcat in my npm bin:

```
% make
cd pkg && make all
make[1]: mapcat: No such file or directory
make[1]: *** [annotator.js] Error 1
make: *** [all] Error 2
```

It seems that unless you set PATH explicitly it falls back to using the user's shell which doesn't have the altered PATH. At least that was my hasty reading of [the doc](https://www.gnu.org/software/make/manual/html_node/Choosing-the-Shell.html). I'm guessing that others who have run this happened to have mapcat installed globally so they never noticed this.

I also added the document plugin to the list of plugins package, and switched back to spec reporter for tests since I like to see which tests are actually running. 
