### PR TITLE
filter plugin for tags was not working as expected.  Regex expression to check for white space needed to be changed.

### DIFF
--- a/src/plugin/filter.coffee
+++ b/src/plugin/filter.coffee
@@ -66,7 +66,7 @@ class Annotator.Plugin.Filter extends Annotator.Plugin
     isFiltered: (input, property) ->
       return false unless input and property
 
-      for keyword in (input.split /\s*/)
+      for keyword in (input.split /\s+/)
         return false if property.indexOf(keyword) == -1
 
       return true


### PR DESCRIPTION
input.split /\s*/ was not producing the desired result. It was taking the filter input for tags and looking for each letter instead of the word.  changing regex to /\s+/ seemed to fix things.
