### PR TITLE
Replace $.live with $.on in the demo. Fixes #254

### DIFF
--- a/main.js
+++ b/main.js
@@ -20,7 +20,7 @@
     }
   }
 
-  $('a[href^="#"]').live('click', function (event) {
+  $(document).on('click', 'a[href^="#"]', function (event) {
     var section = $(this.hash);
     if (section.length) {
       scrollTo(section.offset());


### PR DESCRIPTION
`jQuery.live` was deprecated in 1.7 and removed in 1.9.

The demo currently sources jQuery 1.9.1, uses $.live to listen for clicks, and it's busted for me on latest Chrome.

This fix gets the annotator demo working for me on localhost.
