### PR TITLE
Remove notification level after hiding. Fixes #200

### DIFF
--- a/src/notification.coffee
+++ b/src/notification.coffee
@@ -53,9 +53,10 @@ class Annotator.Notification extends Delegator
   #
   # Returns itself.
   show: (message, status=Annotator.Notification.INFO) =>
+    @currentStatus = status
     $(@element)
       .addClass(@options.classes.show)
-      .addClass(@options.classes[status])
+      .addClass(@options.classes[@currentStatus])
       .html(Util.escape(message || ""))
 
     setTimeout this.hide, 5000
@@ -70,7 +71,10 @@ class Annotator.Notification extends Delegator
   #
   # Returns itself.
   hide: =>
-    $(@element).removeClass(@options.classes.show)
+    @currentStatus ?= Annotator.Notification.INFO
+    $(@element)
+      .removeClass(@options.classes.show)
+      .removeClass(@options.classes[@currentStatus])
     this
 
 # Constants for controlling the display of the notification. Each constant


### PR DESCRIPTION
@tilgovi this is a start on notifications work--submitted mainly to get feedback, doesn't seem mergeable yet.

I'm having trouble getting the notifications test to fail. First off, [the relevant assertion](https://github.com/okfn/annotator/blob/master/test/spec/notification_spec.coffee#L29-L30) is typoed, but if I change it to verify that the class `annotator-notice-show` is gone, the test passes. It shouldn't.

I do see in the dev.html page that, with this change added, the annotator-notice-\* classes are removed on hide.

What am I missing?

I've got a start on queueing notifications, will code it up after I get the tests fixed. Basic idea is, show() queues up the message/status, then calls _show(). _show() checks if the queue has length; if it does, shift the zeroth entry and display it. hide() should call _show() after hiding the element, to get to the next item in the queue after the element is clicked or the hide timer runs out. Feedback welcome on this approach.
