### PR TITLE
Restore the ability for plugins to set Store headers

### DIFF
--- a/src/plugin/auth.coffee
+++ b/src/plugin/auth.coffee
@@ -121,6 +121,10 @@ class Annotator.Plugin.Auth extends Annotator.Plugin
     # List of functions to be executed when we have a valid token.
     @waitingForToken = []
 
+  # Public: Initialises the plugin.
+  #
+  # Returns nothing.
+  pluginInit: ->
     if @options.token
       this.setToken(@options.token)
     else
@@ -222,16 +226,12 @@ class Annotator.Plugin.Auth extends Annotator.Plugin
 
     if (timeToExpiry > 0) then timeToExpiry else 0
 
-  # Public: Updates the headers to be sent with the Store requests. This is
-  # achieved by updating the 'annotator:headers' key in the @element.data()
-  # store.
+  # Public: Updates the headers to be sent with the Store requests.
   #
   # Returns nothing.
   updateHeaders: ->
-    current = @element.data('annotator:headers')
-    @element.data('annotator:headers', $.extend(current, {
-      'x-annotator-auth-token': @token,
-    }))
+    if this.annotator.store?.setHeader?
+      this.annotator.store.setHeader('x-annotator-auth-token', @token)
 
   # Runs the provided callback if a valid token is available. Otherwise requests
   # a token until it recieves a valid one.

--- a/src/plugin/store.coffee
+++ b/src/plugin/store.coffee
@@ -8,16 +8,8 @@ Annotator = require('annotator')
 # the event.
 #
 # The store handles five distinct actions "read", "search", "create", "update"
-# and "destory". The requests made can be customised with options when the
-# plugin is added to the Annotator. Custom headers can also be sent with every
-# request by setting a $.data key on the Annotation#element containing headers
-# to send. e.g:
-#
-#   annotator.element.data('annotation:headers', {
-#     'X-My-Custom-Header': 'MyCustomValue'
-#   })
-#
-# This header will now be sent with every request.
+# and "destroy". The requests made can be customised with options when the
+# plugin is added to the Annotator.
 class Annotator.Plugin.Store
 
   # User customisable options available.
@@ -37,6 +29,10 @@ class Annotator.Plugin.Store
     # Should the plugin emulate JSON POST/PUT payloads by sending its requests
     # as application/x-www-form-urlencoded with a single key, "json"
     emulateJSON: false
+
+    # A set of custom headers that will be sent with every request. See also the
+    # setHeader method.
+    headers: {}
 
     # This is the API endpoint. If the server supports Cross Origin Resource
     # Sharing (CORS) a full URL can be used here.
@@ -136,6 +132,19 @@ class Annotator.Plugin.Store
         dfd.reject.apply(dfd, arguments)
     return dfd.promise()
 
+  # Public: Set a custom HTTP header to be sent with every request.
+  #
+  # key   - The header name.
+  # value - The header value.
+  #
+  # Examples:
+  #
+  #   store.setHeader('X-My-Custom-Header', 'MyCustomValue')
+  #
+  # Returns nothing.
+  setHeader: (key, value) ->
+    this.options.headers[key] = value
+
   # Callback method for Store#loadAnnotationsFromSearch(). Processes the data
   # returned from the server (a JSON array of annotation Objects) and updates
   # the registry as well as loading them into the Annotator.
@@ -179,7 +188,8 @@ class Annotator.Plugin.Store
     opts = {
       type:     method,
       dataType: "json",
-      error:    this._onError
+      error:    this._onError,
+      headers:  this.options.headers
     }
 
     # If emulateHTTP is enabled, we send a POST and put the real method in an

--- a/test/spec/plugin/auth_spec.coffee
+++ b/test/spec/plugin/auth_spec.coffee
@@ -81,16 +81,18 @@ describe 'Annotator.Plugin.Auth', ->
   beforeEach ->
     {rawToken, encodedToken} = makeToken()
     mock = mockAuth({token: encodedToken, autoFetch: false})
+    mock.auth.annotator =
+      store:
+        setHeader: sinon.spy()
+    mock.auth.pluginInit()
 
   it "uses token supplied in options by default", ->
     assert.equal(mock.auth.token, encodedToken)
 
   xit "makes an ajax request to tokenUrl to retrieve token otherwise"
 
-  it "sets annotator:headers data on its element with token data", ->
-    data = $(mock.elem).data('annotator:headers')
-    assert.isNotNull(data)
-    assert.equal(data['x-annotator-auth-token'], encodedToken)
+  it "sets a custom store header with token data", ->
+    assert.isTrue(mock.auth.annotator.store.setHeader.calledWith('x-annotator-auth-token', encodedToken))
 
   it "should call callbacks given to #withToken immediately if it has a valid token", ->
     callback = sinon.spy()

--- a/test/spec/plugin/store_spec.coffee
+++ b/test/spec/plugin/store_spec.coffee
@@ -12,15 +12,6 @@ describe "Annotator.Plugin.Store", ->
   afterEach ->
     $.ajax.restore()
 
-  xit "should somehow ensure that it sends auth tokens if necessary"
-    # authMock = {
-    #   withToken: sinon.spy()
-    # }
-    # store.annotator.plugins.Auth = authMock
-
-    # store.pluginInit()
-    # assert.isTrue(authMock.withToken.calledWith(store._getAnnotations))
-
   it "create should trigger a POST request", ->
     store.create({text: "Donkeys on giraffes"})
     [_, opts] = $.ajax.args[0]
@@ -103,25 +94,13 @@ describe "Annotator.Plugin.Store", ->
     [url, _] = $.ajax.args[1]
     assert.equal('/some/prefix/delete?id=123&foo', url)
 
-  xit "should allow plugins to set custom headers (...from the data property 'annotator:headers'?)"
-    # sinon.stub(store, '_methodFor').returns('GET')
-    # sinon.stub(store.element, 'data').returns({
-    #   'x-custom-header-one':   'mycustomheader'
-    #   'x-custom-header-two':   'mycustomheadertwo'
-    #   'x-custom-header-three': 'mycustomheaderthree'
-    # })
-
-    # action   = 'read'
-    # data     = {}
-
-    # options = store._apiRequestOptions(action, data)
-
-    # assert.deepEqual(options.headers, {
-    #   'x-custom-header-one':   'mycustomheader'
-    #   'x-custom-header-two':   'mycustomheadertwo'
-    #   'x-custom-header-three': 'mycustomheaderthree'
-    # })
-
+  it "should send custom headers added with setHeader", ->
+    store.setHeader('Fruit', 'Apple')
+    store.setHeader('Colour', 'Green')
+    store.create({text: "Donkeys on giraffes"})
+    [_, opts] = $.ajax.args[0]
+    assert.equal('Apple', opts.headers['Fruit'])
+    assert.equal('Green', opts.headers['Colour'])
 
   it "should emulate new-fangled HTTP if emulateHTTP is true", ->
     store.options.emulateHTTP = true


### PR DESCRIPTION
The Auth plugin in the v1.2.x series relies on the Store header parsing
the value of a jQuery `annotator:headers` field on the annotation
element in order to set the auth token header on requests to the store.

This functionality got lost in the refactoring of the Store plugin,
which I don't believe is a bad thing (for one, the implementation fell
far short of the "Tell, Don't Ask"[1](http://pragprog.com/articles/tell-dont-ask) design philosophy).

We still need a way to get headers into the Store plugin, at least for
now, so this commit adds a `setHeader` method to the Store plugin, and
updates the Auth plugin to use that.
