### PR TITLE
Make hover less sticky by following the cursor on changes, and simplify

### DIFF
--- a/src/annotator.coffee
+++ b/src/annotator.coffee
@@ -665,25 +665,14 @@ class Annotator extends Delegator
     # Don't do anything if we're making a selection
     return false if @mouseIsDown
 
+    # If the viewer is already shown, hide it first
+    @viewer.hide() if @viewer.isShown()
+
     annotations = $(event.target)
       .parents('.annotator-hl')
       .addBack()
-      .map -> return $(this).data("annotation")
-
-    annotations = $.makeArray(annotations)
-
-    # If the viewer is already shown, we have to react differently
-    if @viewer.isShown()
-      # Check whether the annotations already shown in the viewer are
-      # the same ones we are currently hovering over
-      if Util.setsAreEqual(annotations, @viewer.annotations)
-        # Viewer already contains the currently wanted annotations.
-        # nothing to do.
-        return false
-      else
-        # Viewer contains a different set of annotations.
-        # We should hide it first.
-        @viewer.hide()
+      .map( -> return $(this).data("annotation"))
+      .toArray()
 
     # Now show the viewer with the wanted annotations
     this.showViewer(annotations, Util.mousePosition(event, @wrapper[0]))

--- a/src/util.coffee
+++ b/src/util.coffee
@@ -40,21 +40,6 @@ Util.flatten = (array) ->
 
   flatten(array)
 
-# Public: check if two arrays are equal. (Order does not count.)
-Util.setsAreEqual = (set1, set2) ->
-  throw new Error "set1 is missing!" unless set1?
-  throw new Error "set2 is missing!" unless set2?
-  return true if set1 is set2
-  return false unless set1.length is set2.length
-
-  # OK, so we know that each sets has the same size.
-  # Now we just need to confirm that each elements of set1 exists in set2,
-  # too
-  for element in set1
-    return false unless element in set2
-
-  # If there were a missing element, we wouln't be executing this.
-  true
 
 # Public: decides whether node A is an ancestor of node B.
 #


### PR DESCRIPTION
Now we don't check for the previously displayed set of annotations,
just hide and show again.
