### PR TITLE
annotationData does not get added to store in v2

### DIFF
--- a/src/plugin/store.coffee
+++ b/src/plugin/store.coffee
@@ -1,6 +1,7 @@
 Annotator = require('annotator')
-$ = Annotator.Util.$
-_t = Annotator.Util.TranslationString
+Util = Annotator.Util
+$ = Util.$
+_t = Util.TranslationString
 
 
 # Public: The Store plugin can be used to persist annotations to a database
@@ -19,7 +20,9 @@ class Store
 
     # Custom meta data that will be attached to every annotation that is sent
     # to the server. This _will_ override previous values.
-    annotationData: {}
+    #
+    # @slatedForDeprecation 2.1.0
+    annotationData: null
 
     # Should the plugin emulate HTTP methods like PUT and DELETE for
     # interaction with legacy web servers? Setting this to `true` will fake
@@ -203,6 +206,18 @@ class Store
     if action is "search"
       opts = $.extend(opts, data: obj)
       return opts
+
+    # Add annotationData to object, if specified
+    #
+    # @slatedForDeprecation 2.1.0
+    if @options.annotationData?
+      Util.deprecationWarning("Use of the annotationData option to the Store
+                               plugin is deprecated and will be removed in a
+                               future version. Please use hooks to
+                               beforeAnnotationCreated and
+                               beforeAnnotationUpdated to replicate this
+                               behaviour.")
+      $.extend(obj, @options.annotationData)
 
     data = obj && JSON.stringify(obj)
 

--- a/test/spec/plugin/store_spec.coffee
+++ b/test/spec/plugin/store_spec.coffee
@@ -130,6 +130,13 @@ describe "Store plugin", ->
       json: '{"id":123}',
     })
 
+  it "should extend the annotation with the content of annotationData", ->
+    store.options.annotationData = {custom: 'value', customArray: []}
+    store.create({id: 123})
+    [_, opts] = $.ajax.args[0]
+
+    assert.equal('{"id":123,"custom":"value","customArray":[]}', opts.data)
+
   describe "_onError", ->
     message = null
     requests = [


### PR DESCRIPTION
The store plugin in current master does not add annotationData to the submitted data.

my quick fix (starting at line 195):

```
 # add annotationData
    if action is "create" or action is "update"
      obj = $.extend(obj, @options.annotationData)
```

(see https://github.com/robcast/annotator/blob/master/src/plugin/store.coffee)

or am i missing something?
