### PR TITLE
Restore support for legacy instantiation of Store

### DIFF
--- a/src/annotator.coffee
+++ b/src/annotator.coffee
@@ -43,12 +43,8 @@ class Annotator extends Delegator
     wrapper: '<div class="annotator-wrapper"></div>'
 
   options: # Configuration options
-    # Store plugin to use. If null, Annotator will use a default store.
-    store: null
     # Start Annotator in read-only mode. No controls will be shown.
     readOnly: false
-    # Initial query to load Annotations
-    loadQuery: {}
 
   plugins: {}
 
@@ -107,10 +103,7 @@ class Annotator extends Delegator
       # than being created by a Factory instance. Create the Factory ourselves
       # and use it to bootstrap.
       factory = new Factory()
-      if @options.store
-        factory.setStore(@options.store.type, @options.store)
-      else
-        factory.setStore(NullStore)
+      factory.setStore(NullStore)
       factory.configureInstance(this)
 
       this.attach(element)
@@ -150,9 +143,6 @@ class Annotator extends Delegator
 
     # Create adder
     this.adder = $(this.html.adder).appendTo(@wrapper).hide()
-
-    # Do initial load
-    if @options.loadQuery then this.load(@options.loadQuery)
 
     for name of @plugins
       p = @plugins[name]

--- a/src/plugin/store.coffee
+++ b/src/plugin/store.coffee
@@ -76,7 +76,25 @@ class Store
   #
   # Returns a new instance of Store.
   constructor: (options) ->
+    # If instantiated in legacy mode with annotator.addPlugin('Store', {...}),
+    # then the first argument will be the Annotator's element. We don't need the
+    # element: discard it.
+    if arguments.length > 1
+      options = arguments[1]
+
     @options = $.extend(true, {}, @options, options)
+
+    if @options.loadFromSearch
+      Util.deprecationWarning("Use of the loadFromSearch option to the Store
+                               plugin is deprecated. Please call
+                               .load(queryObj) on the Annotator instance
+                               instead.")
+
+  # Support for legacy instantiation of Store plugin with .addPlugin('Store')
+  pluginInit: ->
+    @annotator.store = this
+    if @options.loadFromSearch
+      @annotator.load(@options.loadFromSearch)
 
   # Public: Callback method for annotationCreated event. Receives an annotation
   # and sends a POST request to the sever using the URI for the "create" action.


### PR DESCRIPTION
Allow people to use the old method of adding the Store plugin, and in
particular, restore support for the loadFromSearch option.
