### PR TITLE
Remove unused "read" action from Store plugin

### DIFF
--- a/doc/plugins/store.rst
+++ b/doc/plugins/store.rst
@@ -9,9 +9,6 @@ Actions
 
 The following actions are performed by the annotator.
 
--  ``read``: GETs all annotations. Called when plugin loads or
-   ``.loadAnnotations()`` is called. Server should return an array of
-   annotations serialised as JSON.
 -  ``create``: POSTs an annotation (serialised as JSON) to the server.
    Called when the annotator publishes the "annotationCreated" event.
    The annotation is updated with any data (such as a newly created id)
@@ -61,8 +58,8 @@ retrieve the annotator object using ``.data('annotator')``. Then add the
             'uri': 'http://this/document/only'
           },
 
-          // This will perform a "search" action rather than "read" when the plugin
-          // loads. Will request the last 20 annotations for the current url.
+          // This will perform a "search" action when the plugin loads. Will
+          // request the last 20 annotations for the current url.
           // eg. /store/endpoint/search?limit=20&uri=http://this/document/only
           loadFromSearch: {
             'limit': 20,
@@ -150,7 +147,6 @@ Methods for actions are as follows:
 
 ::
 
-    read:    GET
     create:  POST
     update:  PUT
     destroy: DELETE
@@ -164,7 +160,6 @@ Example:
         urls: {
           // These are the default URLs.
           create:  '/annotations',
-          read:    '/annotations/:id',
           update:  '/annotations/:id',
           destroy: '/annotations/:id',
           search:  '/search'

--- a/src/plugin/store.coffee
+++ b/src/plugin/store.coffee
@@ -10,8 +10,8 @@ _t = Util.TranslationString
 # by the Annotator and making appropriate requests to the server depending on
 # the event.
 #
-# The store handles five distinct actions "read", "search", "create", "update"
-# and "destroy". The requests made can be customised with options when the
+# The store handles four distinct actions: "search", "create", "update" and
+# "destroy". The requests made can be customised with options when the
 # plugin is added to the Annotator.
 class Store
 
@@ -47,14 +47,12 @@ class Store
     # must respond to the appropraite HTTP method. The token ":id" can be used
     # anywhere in the URL and will be replaced with the annotation id.
     #
-    # read:    GET
     # create:  POST
     # update:  PUT
     # destroy: DELETE
     # search:  GET
     urls:
       create: '/annotations'
-      read: '/annotations/:id'
       update: '/annotations/:id'
       destroy: '/annotations/:id'
       search: '/search'
@@ -174,15 +172,18 @@ class Store
   # Returns the jQuery XMLHttpRequest wrapper enabling additional callbacks to
   # be applied as well as custom error handling.
   #
-  # action    - The action String eg. "read", "search", "create", "update"
-  #             or "destory".
+  # action    - The action String: "search", "create", "update" or "destroy".
   # obj       - The data to be sent, either annotation object or query string.
   # onSuccess - A callback Function to call on successful request.
   #
   # Examples:
   #
-  #   store._apiRequest('read', {id: 4}, (data) -> console.log(data))
-  #   # => Outputs the annotation returned from the server.
+  #   store._apiRequest(
+  #     'create',
+  #     {text: "Donkeys!!"},
+  #     function (data) { console.log(data); } # Prints the annotation returned
+  #                                            # from the server.
+  #   );
   #
   # Returns XMLHttpRequest object.
   _apiRequest: (action, obj) ->
@@ -200,8 +201,7 @@ class Store
 
   # Builds an options object suitable for use in a jQuery.ajax() call.
   #
-  # action    - The action String eg. "read", "search", "create", "update"
-  #             or "destroy".
+  # action    - The action String: "search", "create", "update" or "destroy".
   # obj       - The data to be sent, either annotation object or query string.
   #
   # Returns Object literal of $.ajax() options.
@@ -285,7 +285,6 @@ class Store
   #
   # Examples
   #
-  #   store._methodFor('read')    # => "GET"
   #   store._methodFor('update')  # => "PUT"
   #   store._methodFor('destroy') # => "DELETE"
   #
@@ -293,7 +292,6 @@ class Store
   _methodFor: (action) ->
     table =
       create: 'POST'
-      read: 'GET'
       update: 'PUT'
       destroy: 'DELETE'
       search: 'GET'
@@ -312,10 +310,6 @@ class Store
 
     if xhr._action == 'search'
       message = _t("Sorry we could not search the store for annotations")
-    else if xhr._action == 'read' && !xhr._id
-      message = _t("Sorry we could not ") +
-                action +
-                _t(" the annotations from the store")
 
     switch xhr.status
       when 401

--- a/test/spec/plugin/store_spec.coffee
+++ b/test/spec/plugin/store_spec.coffee
@@ -142,9 +142,7 @@ describe "Store plugin", ->
     requests = [
       {}
       {}
-      {_action: 'read', _id: 'jim'}
       {_action: 'search'}
-      {_action: 'read'}
       {status: 401, _action: 'delete', '_id': 'cake'}
       {status: 404, _action: 'delete', '_id': 'cake'}
       {status: 500, _action: 'delete', '_id': 'cake'}
@@ -168,14 +166,8 @@ describe "Store plugin", ->
     it "should call console.error with a message", ->
       assert(console.error.calledOnce)
 
-    it "should give a default message if xhr.status id not provided", ->
-      assert.equal(message, "Sorry we could not read this annotation")
-
     it "should give a default specific message if xhr._action is 'search'", ->
       assert.equal(message, "Sorry we could not search the store for annotations")
-
-    it "should give a default specific message if xhr._action is 'read' and there is no xhr._id", ->
-      assert.equal(message, "Sorry we could not read the annotations from the store")
 
     it "should give a specific message if xhr.status == 401", ->
       assert.equal(message, "Sorry you are not allowed to delete this annotation")


### PR DESCRIPTION
The "read" action is unused by the current implementation of the Store plugin.
All retrieval of annotations is done through the .query() method, which maps
to the "search" action.

<!---
@huboard:{"order":155.0,"custom_state":""}
-->
