### PR TITLE
conditional comments for IE-only JS stuff

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -7,7 +7,9 @@
     <!-- If you're sure your users will only be using browsers modern
          enough to have their own JSON.parse and JSON.stringify
          implementations you can skip this -->
+    <!--[if lt IE 9]>
     <script src="lib/vendor/json2.js"></script>
+    <![endif]-->
 
     <!-- Needed for Internet Explorer compatibility, providing
          the missing document.evaluate() -->

--- a/dev.html
+++ b/dev.html
@@ -5,7 +5,9 @@
     <title>JS annotation test</title>
 
     <script src="lib/vendor/jquery.js"></script><!-- dynamically provided -->
+    <!--[if lt IE 9]>
     <script src="lib/vendor/json2.js"></script>
+    <![endif]-->
     <script src="/lib/vendor/wgxpath.install.js"></script>
 
     <script src="lib/annotator.js"></script>

--- a/dev.xhtml
+++ b/dev.xhtml
@@ -6,7 +6,9 @@
     <title>JS annotation test</title>
 
     <script src="lib/vendor/jquery.js"></script>
+    <!--[if lt IE 9]>
     <script src="lib/vendor/json2.js"></script>
+    <![endif]-->
     <script src="/lib/vendor/wgxpath.install.js"></script>
 
     <script src="lib/annotator.js"></script>

--- a/example/openshakespeare/index.html
+++ b/example/openshakespeare/index.html
@@ -5,7 +5,9 @@
     <title>OpenShakespeare demo</title>
 
     <script src="../../lib/vendor/jquery.js"></script>
+    <!--[if lt IE 9]>
     <script src="../../lib/vendor/json2.js"></script>
+    <![endif]-->
 
     <script src="../../lib/annotator.js"></script>
     <script src="../../lib/plugin/store.js"></script>

--- a/test/runner.html
+++ b/test/runner.html
@@ -13,7 +13,9 @@
 
     <script src="/lib/vendor/wgxpath.install.js"></script>
     <script src="/lib/vendor/jquery.js"></script><!-- provided dynamically -->
+    <!--[if lt IE 9]>
     <script src="/lib/vendor/json2.js"></script>
+    <![endif]-->
     <script src="/lib/vendor/showdown.js"></script>
     <script src="/node_modules/mocha/mocha.js"></script>
     <script src="/node_modules/chai/chai.js"></script>


### PR DESCRIPTION
json2 and (afaik) wgxpath aren't useful to any other browsers, and subsequently aren't worth the network traffic to download them.

Saving the endangered bandwidth beast. :wink: 
