### PR TITLE
Don't dynamically change input type.

### DIFF
--- a/src/plugin/editor.coffee
+++ b/src/plugin/editor.coffee
@@ -222,7 +222,8 @@ class Editor extends Widget
 
     switch (field.type)
       when 'textarea'          then input = $('<textarea />')
-      when 'input', 'checkbox' then input = $('<input />')
+      when 'checkbox' then input = $('<input type="checkbox" />')
+      when 'input' then input = $('<input />')
       when 'select' then input = $('<select />')
 
     element.append(input)
@@ -233,7 +234,6 @@ class Editor extends Widget
     })
 
     if field.type == 'checkbox'
-      input[0].type = 'checkbox'
       element.addClass('annotator-checkbox')
       element.append($('<label />', {for: field.id, html: field.label}))
 


### PR DESCRIPTION
Older IE versions don't allow modifying types.  Will resolve https://github.com/openannotation/annotator/issues/409.

I'm not seeing anything too weird in here, and tests pass - but someone else with a live instance might want to try this out first.
