### PR TITLE
Add NPM Version number output

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Annotator
 =========
 
-|Build Status| |Stories in Ready|
+|Build Status| |Stories in Ready| |Version on NPM|
 
 Annotator is a JavaScript library for building annotation systems on the web. It
 provides a set of tools to annotate text (and other content) in webpages, and to
@@ -104,3 +104,5 @@ encouraged to use for any questions and discussions. We can also be found in
    :target: http://travis-ci.org/openannotation/annotator
 .. |Stories in Ready| image:: https://badge.waffle.io/openannotation/annotator.png?label=ready&title=Ready
    :target: https://waffle.io/openannotation/annotator
+.. |Version on NPM| image:: http://img.shields.io/npm/v/annotator.svg
+   :target: https://www.npmjs.org/package/annotator


### PR DESCRIPTION
I'd love to add badges for license too, but couldn't figure out if NPM's package format supports multiple versions or not (or how [shields.io](http://shields.io/) would handle that either...).

Figure this would make it faster to spot discrepancies, ala #433.
