### PR TITLE
Introduce defaultRenderer for Viewer

### DIFF
--- a/src/ui/viewer.js
+++ b/src/ui/viewer.js
@@ -82,11 +82,17 @@ var Viewer = Widget.extend({
         this.hideTimerActivity = null;
         this.mouseDown = false;
 
+        function defaultTextRenderer(text) {
+            return Util.escapeHtml(text);
+        }
+        var renderText = this.options.renderText || defaultTextRenderer;
+
+        var self = this;
         if (this.options.defaultFields) {
             this.addField({
                 load: function (field, annotation) {
                     if (annotation.text) {
-                        $(field).html(Util.escapeHtml(annotation.text));
+                        $(field).html(renderText(annotation.text));
                     } else {
                         $(field).html("<i>" + _t('No Comment') + "</i>");
                     }
@@ -106,8 +112,6 @@ var Viewer = Widget.extend({
         if (typeof this.options.permitDelete !== 'function') {
             throw new TypeError("permitDelete callback must be a function");
         }
-
-        var self = this;
 
         if (this.options.autoViewHighlights) {
             this.document = this.options.autoViewHighlights.ownerDocument;

--- a/test/spec/ui/viewer_spec.js
+++ b/test/spec/ui/viewer_spec.js
@@ -255,6 +255,29 @@ describe('UI.Viewer', function () {
         });
     });
 
+    describe('renderText', function () {
+        var renderText = null;
+
+        beforeEach(function () {
+            renderText = sinon.stub().returns("Wolves with sheep");
+
+            v = new UI.Viewer({
+                defaultFields: true,
+                renderText: renderText
+            });
+        });
+
+        afterEach(function () {
+            v.destroy();
+        });
+
+        it('calls the defaultRenderer to render the text field.', function () {
+            v.load([{text: "Tigers with cameras"}]);
+            var html = v.element.html();
+            assert.isTrue(html.indexOf("Wolves with sheep") >= 0);
+        });
+    });
+
     describe('event handlers', function () {
         var hl = null,
             clock = null;


### PR DESCRIPTION
This PR is a prerequisite for reworking the Markdown plugin (https://github.com/hypothesis/vision/issues/125).

It introduces a new option (called `defaultRenderer`) for the `Viewer`.
What it does is only, if this option is set (of course the `defaultField` needs to set to true) then it calls the given function to produce the rendered text field.

I think the html sanitization should be the responsibility of the set function.
