### PR TITLE
Check for plugin#destroy() before calling it

### DIFF
--- a/src/annotator.coffee
+++ b/src/annotator.coffee
@@ -202,7 +202,7 @@ class Annotator extends Delegator
     @element.data('annotator', null)
 
     for name, plugin of @plugins
-      @plugins[name].destroy()
+      @plugins[name].destroy?()
 
     idx = Annotator._instances.indexOf(this)
     if idx != -1

--- a/test/spec/annotator_spec.coffee
+++ b/test/spec/annotator_spec.coffee
@@ -97,6 +97,16 @@ describe 'Annotator', ->
       annotator.destroy()
       assert.equal(annotator.element.find('[class^=annotator-]').length, 0)
 
+    it "should call destroy on loaded plugins", ->
+      spy = sinon.spy()
+      annotator.myPlugin = {destroy: spy}
+      annotator.destroy()
+      assert(spy)
+
+    it "should not call destroy on a plugin that has not implemented the method", ->
+      annotator.plugins.myPlugin = {}
+      assert.doesNotThrow -> annotator.destroy()
+
   describe "_setupDocumentEvents", ->
     beforeEach: ->
       $(document).unbind('mouseup').unbind('mousedown')


### PR DESCRIPTION
This was causing errors to be raised if a plugin did not implement the destroy method.