### PR TITLE
Reference `annotator` as an external dependency

### DIFF
--- a/contrib/plugintools/README.rst
+++ b/contrib/plugintools/README.rst
@@ -19,7 +19,7 @@ the Annotator library, such as ``Annotator.UI``, ``Annotator.Storage``, etc.
 
 You can then build your plugin using browserify:
 
-    browserify myplugin.js > myplugin.bundle.js
+    browserify -x annotator myplugin.js > myplugin.bundle.js
 
 The output will be a bundle that can be included in your page after the main
 Annotator bundle:


### PR DESCRIPTION
Since the recommendation is to use `<script>` to include annotator, browserify needs to know not to try and request it during build.

This fixes the browserify line so it works. :smiley: