### PR TITLE
Better overlapping highlight allowance

### DIFF
--- a/src/annotator.coffee
+++ b/src/annotator.coffee
@@ -573,8 +573,6 @@ class Annotator extends Delegator
 
     for range in @selectedRanges
       container = range.commonAncestor
-      if $(container).hasClass('annotator-hl')
-        container = $(container).parents('[class!=annotator-hl]')[0]
       return if this.isAnnotator(container)
 
     if event and @selectedRanges.length
@@ -599,7 +597,13 @@ class Annotator extends Delegator
   #
   # Returns true if the element is a child of an annotator element.
   isAnnotator: (element) ->
-    !!$(element).parents().addBack().filter('[class^=annotator-]').not(@wrapper).length
+    !!$(element)
+      .parents()
+      .addBack()
+      .filter('[class^=annotator-]')
+      .not('[class=annotator-hl]')
+      .not(@wrapper)
+      .length
 
   # Annotator#element callback. Displays viewer with all annotations
   # associated with highlight Elements under the cursor.

--- a/test/spec/annotator_spec.coffee
+++ b/test/spec/annotator_spec.coffee
@@ -819,6 +819,10 @@ describe 'Annotator', ->
       for element in elements
         assert.isFalse(annotator.isAnnotator(element))
 
+    it "should ignore the annotator highlight elements", ->
+      element = $('<span class="annotator-hl"></span>')[0]
+      assert.isFalse(annotator.isAnnotator(element))
+
   describe "onHighlightMouseover", ->
     element = null
     mockEvent = null


### PR DESCRIPTION
The `isAnnotator` method can ignore the highlight spans, making it a
simple call to `isAnnotator` when ignoring selections, rather than a
loop that tries to escape the highlights.

Close #466