### PR TITLE
Put shortlinks into the metadata

### DIFF
--- a/src/plugin/document.coffee
+++ b/src/plugin/document.coffee
@@ -108,7 +108,7 @@ class Annotator.Plugin.Document extends Annotator.Plugin
       type = l.prop('type')
       lang = l.prop('hreflang')
 
-      if rel not in ["alternate", "canonical", "bookmark"] then continue
+      if rel not in ["alternate", "canonical", "bookmark", "shortlink"] then continue
 
       if rel is 'alternate'
         # Ignore feeds resources

--- a/test/spec/plugin/document_spec.coffee
+++ b/test/spec/plugin/document_spec.coffee
@@ -22,6 +22,7 @@ describe 'Annotator.Plugin.Document', ->
     head.append('<link rel="alternate" href="foo.pdf" type="application/pdf"></link>')
     head.append('<link rel="alternate" href="foo.doc" type="application/msword"></link>')
     head.append('<link rel="bookmark" href="http://example.com/bookmark"></link>')
+    head.append('<link rel="shortlink" href="http://example.com/bookmark/short"></link>')
     head.append('<link rel="alternate" href="es/foo.html" hreflang="es" type="text/html"></link>')
     head.append('<meta name="citation_doi" content="10.1175/JCLI-D-11-00015.1">')
     head.append('<meta name="citation_title" content="Foo">')
@@ -52,7 +53,7 @@ describe 'Annotator.Plugin.Document', ->
 
     it 'should have links with absoulte hrefs and types', ->
       assert.ok(annotation.document.link)
-      assert.equal(annotation.document.link.length, 7)
+      assert.equal(annotation.document.link.length, 8)
       assert.match(annotation.document.link[0].href, /^.+runner.html(\?.*)?$/)
       assert.equal(annotation.document.link[1].rel, "alternate")
       assert.match(annotation.document.link[1].href, /^.+foo\.pdf$/)
@@ -62,13 +63,15 @@ describe 'Annotator.Plugin.Document', ->
       assert.equal(annotation.document.link[2].type, "application/msword")
       assert.equal(annotation.document.link[3].rel, "bookmark")
       assert.equal(annotation.document.link[3].href, "http://example.com/bookmark")
-      assert.equal(annotation.document.link[4].href, "doi:10.1175/JCLI-D-11-00015.1")
-      assert.match(annotation.document.link[5].href, /.+foo\.pdf$/)
-      assert.equal(annotation.document.link[5].type, "application/pdf")
-      assert.equal(annotation.document.link[6].href, "doi:10.1175/JCLI-D-11-00015.1")
+      assert.equal(annotation.document.link[4].rel, "shortlink")
+      assert.equal(annotation.document.link[4].href, "http://example.com/bookmark/short")
+      assert.equal(annotation.document.link[5].href, "doi:10.1175/JCLI-D-11-00015.1")
+      assert.match(annotation.document.link[6].href, /.+foo\.pdf$/)
+      assert.equal(annotation.document.link[6].type, "application/pdf")
+      assert.equal(annotation.document.link[7].href, "doi:10.1175/JCLI-D-11-00015.1")
 
     it 'should ignore atom and RSS feeds and alternate languages', ->
-      assert.equal(annotation.document.link.length, 7)
+      assert.equal(annotation.document.link.length, 8)
 
     it 'should have highwire metadata', ->
       assert.ok(annotation.document.highwire)
@@ -99,7 +102,7 @@ describe 'Annotator.Plugin.Document', ->
     
     it 'should have unique uris', ->
       uris = annotator.plugins.Document.uris()
-      assert.equal(uris.length, 5)
+      assert.equal(uris.length, 6)
 
     it 'should have a favicon', ->
       assert.equal(


### PR DESCRIPTION
v1.2.x backport of PR #470 

We had this fix already in our late-hypothes.is annotator branch, but died with the branch.
So resurrecting it here in its proper place.