### PR TITLE
Clean up markdown and tags modules

### DIFF
--- a/doc/api/ui.rst
+++ b/doc/api/ui.rst
@@ -8,3 +8,6 @@ annotator.ui package
 
 .. include:: ui/markdown.rst
    :start-line: 5
+
+.. include:: ui/tags.rst
+   :start-line: 5

--- a/doc/api/ui.rst
+++ b/doc/api/ui.rst
@@ -5,3 +5,6 @@ annotator.ui package
 
 .. include:: ui/main.rst
    :start-line: 5
+
+.. include:: ui/markdown.rst
+   :start-line: 5

--- a/doc/api/ui/main.rst
+++ b/doc/api/ui/main.rst
@@ -19,5 +19,23 @@ annotator.ui package
     
          A DOM element to which to bind event listeners. Defaults to
          ``document.body``, allowing annotation of the whole document.
+    
+      .. attribute:: options.editorExtensions
+    
+         An array of editor extensions. See the
+         :class:`~annotator.ui.editor.Editor` documentation for details of editor
+         extensions.
+    
+      .. attribute:: options.viewerExtensions
+    
+         An array of viewer extensions. See the
+         :class:`~annotator.ui.viewer.Viewer` documentation for details of viewer
+         extensions.
+    
+      .. attribute:: options.viewerRenderer
+    
+         An annotation renderer for the viewer. See the
+         :class:`~annotator.ui.viewer.Viewer` documentation for details of
+         renderers.
 
 

--- a/doc/api/ui/markdown.rst
+++ b/doc/api/ui/markdown.rst
@@ -1,0 +1,21 @@
+.. default-domain: js
+
+annotator.ui.markdown package
+=============================
+
+..  function:: annotator.ui.markdown.renderer(annotation)
+    
+    A renderer for the :class:`~annotator.ui.viewer.Viewer` which interprets
+    annotation text as `Markdown`_ and uses the `Showdown`_ library if present in
+    the page to render annotations with Markdown text as HTML.
+    
+    .. _Markdown: https://daringfireball.net/projects/markdown/
+    .. _Showdown: https://github.com/showdownjs/showdown
+    
+    **Usage**::
+    
+        app.include(annotator.ui.main, {
+            viewerRenderer: annotator.ui.markdown.renderer
+        });
+
+

--- a/doc/api/ui/tags.rst
+++ b/doc/api/ui/tags.rst
@@ -1,0 +1,30 @@
+.. default-domain: js
+
+annotator.ui.tags package
+=========================
+
+..  function:: annotator.ui.tags.viewerExtension(viewer)
+    
+    An extension for the :class:`~annotator.ui.viewer.Viewer` which displays any
+    tags stored as an array of strings in the annotation's ``tags`` property.
+    
+    **Usage**::
+    
+        app.include(annotator.ui.main, {
+            viewerExtensions: [annotator.ui.tags.viewerExtension]
+        })
+
+
+..  function:: annotator.ui.tags.editorExtension(editor)
+    
+    An extension for the :class:`~annotator.ui.editor.Editor` which allows
+    editing a set of space-delimited tags, retrieved from and saved to the
+    annotation's ``tags`` property.
+    
+    **Usage**::
+    
+        app.include(annotator.ui.main, {
+            viewerExtensions: [annotator.ui.tags.viewerExtension]
+        })
+
+

--- a/src/ui/markdown.js
+++ b/src/ui/markdown.js
@@ -1,3 +1,4 @@
+/*package annotator.ui.markdown */
 "use strict";
 
 var util = require('../util');
@@ -5,34 +6,36 @@ var util = require('../util');
 var g = util.getGlobal();
 var _t = util.gettext;
 
-function markdown() {
-    var converter = null;
+
+/**
+ * function:: renderer(annotation)
+ *
+ * A renderer for the :class:`~annotator.ui.viewer.Viewer` which interprets
+ * annotation text as `Markdown`_ and uses the `Showdown`_ library if present in
+ * the page to render annotations with Markdown text as HTML.
+ *
+ * .. _Markdown: https://daringfireball.net/projects/markdown/
+ * .. _Showdown: https://github.com/showdownjs/showdown
+ *
+ * **Usage**::
+ *
+ *     app.include(annotator.ui.main, {
+ *         viewerRenderer: annotator.ui.markdown.renderer
+ *     });
+ */
+exports.renderer = function renderer(annotation) {
+    var convert = util.escapeHtml;
 
     if (g.Showdown && typeof g.Showdown.converter === 'function') {
-        converter = new g.Showdown.converter();
+        convert = new g.Showdown.converter().makeHtml;
     } else {
-        console.warn(_t("To use the Markdown plugin, you must" +
-        " include Showdown into the page first."));
+        console.warn(_t("To use the Markdown plugin, you must " +
+                        "include Showdown into the page first."));
     }
 
-    // Converts provided text into markdown.
-    //
-    // text - A String of Markdown to render as HTML.
-    //
-    // Examples
-    //
-    // plugin.convert('This is _very_ basic [Markdown](http://daringfireball.com)')
-    // # => Returns "This is <em>very<em> basic <a href="http://...">Markdown</a>"
-    //
-    // Returns HTML string.
-    function convert (text) {
-        text = util.escapeHtml(text || '');
-        return converter ? converter.makeHtml(text) : text;
+    if (annotation.text) {
+        return convert(annotation.text);
+    } else {
+        return "<i>" + _t('No comment') + "</i>";
     }
-
-    return {
-        convert: convert
-    };
-}
-
-exports.markdown = markdown;
+};

--- a/src/ui/tags.js
+++ b/src/ui/tags.js
@@ -1,3 +1,4 @@
+/*package annotator.ui.tags */
 "use strict";
 
 var util = require('../util');
@@ -5,54 +6,40 @@ var util = require('../util');
 var $ = util.$;
 var _t = util.gettext;
 
-// Configuration options
-var defaultOptions = {
-    // Configurable function which accepts an array of tags and
-    // returns a string which will be used to fill the tags input.
-    stringifyTags: function (array) {
-        return array.join(" ");
-    },
-    // Configurable function which accepts a string (the contents)
-    // of the tags input as an argument, and returns an array of
-    // tags.
-    parseTags: function (string) {
-        string = $.trim(string);
-        var tags = [];
+// Take an array of tags and turn it into a string suitable for display in the
+// viewer.
+function stringifyTags(array) {
+    return array.join(" ");
+}
 
-        if (string) {
-            tags = string.split(/\s+/);
-        }
+// Take a string from the tags input as an argument, and return an array of
+// tags.
+function parseTags(string) {
+    string = $.trim(string);
+    var tags = [];
 
-        return tags;
+    if (string) {
+        tags = string.split(/\s+/);
     }
-};
 
-exports.tags = function tags(opts) {
-    var options = $.extend(true, {}, defaultOptions, opts);
+    return tags;
+}
 
-    return {
-        createViewerField: configureViewer(options),
-        createEditorField: configureEditor(options)
-    };
-};
 
-function configureViewer() {
-    // Annotator.Viewer callback function. Updates the annotation display
-    // with tags
-    // removes the field from the Viewer if there are no tags to display.
-    //
-    // field      - The Element to populate with tags.
-    // annotation - An annotation object to be display.
-    //
-    // Examples
-    //
-    //   field = $('<div />')[0]
-    //   plugin.updateField(field, {tags: ['apples']})
-    //   field.innerHTML # => Returns
-    //      '<span class="annotator-tag">apples</span>'
-    //
-    // Returns nothing.
-    function updateViewer (field, annotation) {
+/**
+ * function:: viewerExtension(viewer)
+ *
+ * An extension for the :class:`~annotator.ui.viewer.Viewer` which displays any
+ * tags stored as an array of strings in the annotation's ``tags`` property.
+ *
+ * **Usage**::
+ *
+ *     app.include(annotator.ui.main, {
+ *         viewerExtensions: [annotator.ui.tags.viewerExtension]
+ *     })
+ */
+exports.viewerExtension = function viewerExtension(v) {
+    function updateViewer(field, annotation) {
         field = $(field);
         if (annotation.tags &&
             $.isArray(annotation.tags) &&
@@ -69,71 +56,48 @@ function configureViewer() {
         }
     }
 
-    function createViewerField (v) {
-        v.addField({
-            load: updateViewer
-        });
-    }
-
-    return createViewerField;
-}
+    v.addField({
+        load: updateViewer
+    });
+};
 
 
-function configureEditor(options) {
+/**
+ * function:: editorExtension(editor)
+ *
+ * An extension for the :class:`~annotator.ui.editor.Editor` which allows
+ * editing a set of space-delimited tags, retrieved from and saved to the
+ * annotation's ``tags`` property.
+ *
+ * **Usage**::
+ *
+ *     app.include(annotator.ui.main, {
+ *         viewerExtensions: [annotator.ui.tags.viewerExtension]
+ *     })
+ */
+exports.editorExtension = function editorExtension(e) {
     // The input element added to the Annotator.Editor wrapped in jQuery.
     // Cached to save having to recreate it everytime the editor is displayed.
     var field = null;
     var input = null;
 
-    // Annotator.Editor callback function. Updates the @input field with the
-    // tags attached to the provided annotation.
-    //
-    // field      - The tags field Element containing the input Element.
-    // annotation - An annotation object to be edited.
-    //
-    // Examples
-    //
-    //   field = $('<li><input /></li>')[0]
-    //   plugin.updateField(field, {tags: ['apples', 'oranges', 'cake']})
-    //   field.value # => Returns 'apples oranges cake'
-    //
-    // Returns nothing.
-    function updateField (field, annotation) {
+    function updateField(field, annotation) {
         var value = '';
         if (annotation.tags) {
-            value = options.stringifyTags(annotation.tags);
+            value = stringifyTags(annotation.tags);
         }
         input.val(value);
     }
 
-    // Annotator.Editor callback function. Updates the annotation field with the
-    // data retrieved from the @input property.
-    //
-    // field      - The tags field Element containing the input Element.
-    // annotation - An annotation object to be updated.
-    //
-    // Examples
-    //
-    //   annotation = {}
-    //   field = $('<li><input value="cake chocolate cabbage" /></li>')[0]
-    //
-    //   plugin.setAnnotationTags(field, annotation)
-    //   annotation.tags # => Returns ['cake', 'chocolate', 'cabbage']
-    //
-    // Returns nothing.
-    function setAnnotationTags (field, annotation) {
-        annotation.tags = options.parseTags(input.val());
+    function setAnnotationTags(field, annotation) {
+        annotation.tags = parseTags(input.val());
     }
 
-    function createEditorField (e) {
-        field = e.addField({
-            label: _t('Add some tags here') + '\u2026',
-            load: updateField,
-            submit: setAnnotationTags
-        });
+    field = e.addField({
+        label: _t('Add some tags here') + '\u2026',
+        load: updateField,
+        submit: setAnnotationTags
+    });
 
-        input = $(field).find(':input');
-    }
-
-    return createEditorField;
-}
+    input = $(field).find(':input');
+};

--- a/src/ui/viewer.js
+++ b/src/ui/viewer.js
@@ -82,20 +82,12 @@ var Viewer = exports.Viewer = Widget.extend({
         this.hideTimerActivity = null;
         this.mouseDown = false;
 
-        function defaultTextRenderer(text) {
-            return util.escapeHtml(text);
-        }
-        var renderText = this.options.renderText || defaultTextRenderer;
-
         var self = this;
+
         if (this.options.defaultFields) {
             this.addField({
                 load: function (field, annotation) {
-                    if (annotation.text) {
-                        $(field).html(renderText(annotation.text));
-                    } else {
-                        $(field).html("<i>" + _t('No Comment') + "</i>");
-                    }
+                    $(field).html(self.options.renderer(annotation));
                 }
             });
         }
@@ -488,7 +480,17 @@ Viewer.options = {
 
     // Callback, called when the user clicks the delete button for an
     // annotation.
-    onDelete: function () {}
+    onDelete: function () {},
+
+    // A function that returns the default displayed HTML that represents an
+    // annotation in the viewer.
+    renderer: function (annotation) {
+        if (annotation.text) {
+            return util.escapeHtml(annotation.text);
+        } else {
+            return "<i>" + _t('No comment') + "</i>";
+        }
+    }
 };
 
 

--- a/test/spec/ui/main_spec.js
+++ b/test/spec/ui/main_spec.js
@@ -131,6 +131,18 @@ describe('annotator.ui.main', function () {
             sinon.assert.callCount(mockEditor.addField, 2);
         });
 
+        it("passes editorExtensions on to the editor", function () {
+            editor.Editor.reset();
+            plug = main({
+                element: el,
+                editorExtensions: ['foo', 'bar']
+            });
+            plug.start(mockApp);
+
+            sinon.assert.calledWith(editor.Editor,
+                                    sinon.match.has('extensions', ['foo', 'bar']));
+        });
+
         describe("permissions field load/submit functions", function () {
             var field;
             var viewLoad, viewSubmit;
@@ -203,6 +215,55 @@ describe('annotator.ui.main', function () {
                 viewSubmit(field, ann);
                 assert.deepEqual(ann.permissions, {'read': ['alice']});
             });
+        });
+    });
+
+    describe("Viewer", function () {
+        var el, mockViewer, plug;
+
+        beforeEach(function () {
+            el = $('<div></div>')[0];
+            mockViewer = {
+                addField: sandbox.stub(),
+                destroy: sandbox.stub(),
+                attach: sandbox.stub()
+            };
+            sandbox.stub(viewer, 'Viewer').returns(mockViewer);
+
+            plug = main({element: el});
+            plug.start(mockApp);
+        });
+
+        afterEach(function () {
+            plug.destroy();
+        });
+
+        it("creates a Viewer", function () {
+            sinon.assert.calledOnce(viewer.Viewer);
+        });
+
+        it("passes viewerExtensions on to the viewer", function () {
+            viewer.Viewer.reset();
+            plug = main({
+                element: el,
+                viewerExtensions: ['bar', 'baz']
+            });
+            plug.start(mockApp);
+
+            sinon.assert.calledWith(viewer.Viewer,
+                                    sinon.match.has('extensions', ['bar', 'baz']));
+        });
+
+        it("passes viewerRenderer on to the viewer", function () {
+            viewer.Viewer.reset();
+            plug = main({
+                element: el,
+                viewerRenderer: 'wibble'
+            });
+            plug.start(mockApp);
+
+            sinon.assert.calledWith(viewer.Viewer,
+                                    sinon.match.has('renderer', 'wibble'));
         });
     });
 

--- a/test/spec/ui/viewer_spec.js
+++ b/test/spec/ui/viewer_spec.js
@@ -255,15 +255,10 @@ describe('ui.viewer.Viewer', function () {
         });
     });
 
-    describe('renderText', function () {
-        var renderText = null;
-
+    describe('renderer', function () {
         beforeEach(function () {
-            renderText = sinon.stub().returns("Wolves with sheep");
-
             v = new viewer.Viewer({
-                defaultFields: true,
-                renderText: renderText
+                renderer: sinon.stub().returns("Wolves with sheep")
             });
         });
 
@@ -271,7 +266,7 @@ describe('ui.viewer.Viewer', function () {
             v.destroy();
         });
 
-        it('calls the defaultRenderer to render the text field.', function () {
+        it('uses the renderer to render the annotation', function () {
             v.load([{text: "Tigers with cameras"}]);
             var html = v.element.html();
             assert.isTrue(html.indexOf("Wolves with sheep") >= 0);


### PR DESCRIPTION
In v1.2.x the tags and markdown plugins aren't on by default, so they
probably shouldn't be on by default in the v2.0 user interface.

This PR removes these from the default UI and adds options to
annotator.ui.main which allow for configuration of arbitrary extensions
of Editor and Viewer, as well as the Viewer renderer.

I've also taken the liberty of doing a bit of cleanup and documentation of these two modules.