### PR TITLE
Filter: fix adding filters from options dict

### DIFF
--- a/src/ui/filter.js
+++ b/src/ui/filter.js
@@ -22,7 +22,7 @@ var Filter = exports.Filter = function Filter(options) {
     this.filters = [];
     this.current  = 0;
 
-    for (var i = 0, len = this.options.filters; i < len; i++) {
+    for (var i = 0, len = this.options.filters.length; i < len; i++) {
         var filter = this.options.filters[i];
         this.addFilter(filter);
     }

--- a/test/spec/ui/filter_spec.js
+++ b/test/spec/ui/filter_spec.js
@@ -70,6 +70,44 @@ describe('ui.filter.Filter', function () {
         });
     });
 
+    describe("passing filters to constructor", function () {
+        var testFilter = null;
+
+        beforeEach(function () {
+            testFilter = {
+                label: 'Tag',
+                property: 'tags'
+            };
+            plugin = new filter.Filter({
+                filterElement: element,
+                filters: [testFilter],
+                addAnnotationFilter: false
+            });
+        });
+
+        it("should add a filter object to Filter#plugins", function () {
+            assert.ok(plugin.filters[0]);
+        });
+
+        it("should append the html to Filter#toolbar", function () {
+            testFilter = plugin.filters[0];
+            assert.equal(testFilter.element[0], plugin.element.find('#annotator-filter-tags').parent()[0]);
+        });
+
+        it("should store the filter in the elements data store under 'filter'", function () {
+            testFilter = plugin.filters[0];
+            assert.equal(testFilter.element.data('filter'), plugin.filters[0]);
+        });
+
+        it("should not add a filter for a property that has already been loaded", function () {
+            plugin.addFilter({
+                label: 'Tag',
+                property: 'tags'
+            });
+            assert.lengthOf(plugin.filters, 1);
+        });
+    });
+
     describe("updateFilter", function () {
         var testFilter = null,
             annotations = null;


### PR DESCRIPTION
This fixes adding a filter like this:

```js
    app.include(annotator.ui.filter.standalone, {
      filters: [
        {
          label: 'Tag',
          property: 'tags',
          isFiltered: function (input, tags) { ...}
      ]
    })
```

No test case – happy to add one but I wasn't sure what the idiomatic way to do this would be: inside a new `describe` block, add a new `beforeEach` which re-runs `new filter.Filter` with different arguments?
