### PR TITLE
viewer: don't repeatedly show overlapping annotations

### DIFF
--- a/src/ui/viewer.js
+++ b/src/ui/viewer.js
@@ -126,12 +126,12 @@ var Viewer = exports.Viewer = Widget.extend({
             $(this.document.body)
                 .on("mousedown." + NS, function (e) {
                     if (e.which > 1) {
-                        this.mouseDown = true;
+                        self.mouseDown = true;
                     }
                 })
                 .on("mouseup." + NS, function (e) {
                     if (e.which > 1) {
-                        this.mouseDown = false;
+                        self.mouseDown = false;
                     }
                 });
         }

--- a/src/ui/viewer.js
+++ b/src/ui/viewer.js
@@ -125,12 +125,12 @@ var Viewer = exports.Viewer = Widget.extend({
 
             $(this.document.body)
                 .on("mousedown." + NS, function (e) {
-                    if (e.which > 1) {
+                    if (e.which == 1) {
                         self.mouseDown = true;
                     }
                 })
                 .on("mouseup." + NS, function (e) {
-                    if (e.which > 1) {
+                    if (e.which == 1) {
                         self.mouseDown = false;
                     }
                 });

--- a/src/ui/viewer.js
+++ b/src/ui/viewer.js
@@ -117,7 +117,11 @@ var Viewer = exports.Viewer = Widget.extend({
 
             $(this.options.autoViewHighlights)
                 .on("mouseover." + NS, '.annotator-hl', function (event) {
-                    self._onHighlightMouseover(event);
+                    // If there are many overlapping highlights, still only
+                    // call _onHighlightMouseover once.
+                    if (event.target === this) {
+                        self._onHighlightMouseover(event);
+                    }
                 })
                 .on("mouseleave." + NS, '.annotator-hl', function () {
                     self._startHideTimer();

--- a/test/fixtures/viewer.html
+++ b/test/fixtures/viewer.html
@@ -6,4 +6,5 @@
     <li>First item</li>
     <li>Second item</li>
   </ul>
+  <p><span class="annotator-hl three"><span class="annotator-hl four">Fruit flies like bananas.</span></span></p>
 </div>

--- a/test/spec/ui/filter_spec.js
+++ b/test/spec/ui/filter_spec.js
@@ -125,9 +125,10 @@ describe('ui.filter.Filter', function () {
             };
             annotations = [{text: 'cat'}, {text: 'dog'}, {text: 'car'}];
             plugin.filters = {'text': testFilter};
-            plugin.highlights = {
-                map: function () { return annotations; }
-            };
+            plugin.highlights = $('<span>cat</span><span>dog</span><span>car</span>');
+            plugin.highlights.each(function(i) {
+                $(this).data('annotation', annotations[i]);
+            });
             sandbox.stub(plugin, 'updateHighlights');
             sandbox.stub(plugin, 'resetHighlights');
             sandbox.stub(plugin, 'filterHighlights');


### PR DESCRIPTION
See GH issue #520.

This is problematic because it will break mouseover events on the
highlight's parent, but it does make the page not freeze when you mouse
in and out of a chunk of text with hundreds of annotations.  See
<http://willthompson.co.uk/misc/annotator-freeze-on-mouseout/> for an
example without this patch.

One alternative would be to use a single span.annotation-hl with
multiple annotation-ids where currently they would be nested. ie,
transform this:

```html
<span class="annotation-hl" data-annotation-id="123">
  <span class="annotator-hl" data-annotation-id="456">
    ...
      Foo
    ...
  </span>
</span>
```

into this:

```html
<span class="annotation-hl" data-annotation-id="123 456 ...">
  Foo
</span>
```

Another alternative would be to stick with the current structure but
make the .done() callback inside _onHighlightMouseover smarter about not
repeating itself.