### PR TITLE
Faster highlight creation

### DIFF
--- a/src/ui/highlighter.js
+++ b/src/ui/highlighter.js
@@ -34,7 +34,7 @@ function highlightRange(normedRange, cssClass) {
         var node = nodes[i];
         if (!white.test(node.nodeValue)) {
             results.push(
-                $(node).wrapAll(hl).parent().show()[0]
+                $(node).wrapAll(hl).parent()[0]
             );
         }
     }

--- a/src/ui/highlighter.js
+++ b/src/ui/highlighter.js
@@ -21,8 +21,6 @@ function highlightRange(normedRange, cssClass) {
     }
     var white = /^\s*$/;
 
-    var hl = $("<span class='" + cssClass + "'></span>");
-
     // Ignore text nodes that contain only whitespace characters. This prevents
     // spans being injected between elements that can only contain a restricted
     // subset of nodes such as table rows and lists. This does mean that there
@@ -33,9 +31,11 @@ function highlightRange(normedRange, cssClass) {
     for (var i = 0, len = nodes.length; i < len; i++) {
         var node = nodes[i];
         if (!white.test(node.nodeValue)) {
-            results.push(
-                $(node).wrapAll(hl).parent()[0]
-            );
+            var hl = document.createElement('span');
+            hl.className = cssClass;
+            node.parentNode.replaceChild(hl, node);
+            hl.appendChild(node);
+            results.push(hl);
         }
     }
     return results;


### PR DESCRIPTION
Not the big reorganisation discussed on #521 but this fixes a different big bottleneck for me.

There must be some reason you are calling `.show()` on all the `span`s – perhaps defending against the page having some CSS which applies to all `span`s and hides them or something like that? I'm not sure how big a problem this is in practice, or how to work around it without calling `.show()` – set a defensive `display: inherit;` on `span.annotator-hl` and hope that there's no more specific style in effect?