### PR TITLE
Regression: Fix document uri

### DIFF
--- a/src/plugin/document.coffee
+++ b/src/plugin/document.coffee
@@ -12,7 +12,7 @@ class Annotator.Plugin.Document extends Annotator.Plugin
   
   uri: =>
     uri = decodeURIComponent document.location.href
-    for link in @metadata
+    for link in @metadata.link
       if link.rel == "canonical"
         uri = link.href
     return uri

--- a/test/spec/plugin/document_spec.coffee
+++ b/test/spec/plugin/document_spec.coffee
@@ -36,6 +36,7 @@ describe 'Annotator.Plugin.Document', ->
     head.append('<meta name="eprints.title" content="Computer Lib / Dream Machines">')
     head.append('<meta name="prism.title" content="Literary Machines">')
     head.append('<link rel="alternate" href="feed" type="application/rss+xml"></link>')
+    head.append('<link rel="canonical" href="http://example.com/canonical"></link>')
 
     annotation = null
 
@@ -51,9 +52,9 @@ describe 'Annotator.Plugin.Document', ->
     it 'should have a title, derived from highwire metadata if possible', ->
       assert.equal(annotation.document.title, 'Foo')
 
-    it 'should have links with absoulte hrefs and types', ->
+    it 'should have links with absolute hrefs and types', ->
       assert.ok(annotation.document.link)
-      assert.equal(annotation.document.link.length, 8)
+      assert.equal(annotation.document.link.length, 9)
       assert.match(annotation.document.link[0].href, /^.+runner.html(\?.*)?$/)
       assert.equal(annotation.document.link[1].rel, "alternate")
       assert.match(annotation.document.link[1].href, /^.+foo\.pdf$/)
@@ -65,13 +66,15 @@ describe 'Annotator.Plugin.Document', ->
       assert.equal(annotation.document.link[3].href, "http://example.com/bookmark")
       assert.equal(annotation.document.link[4].rel, "shortlink")
       assert.equal(annotation.document.link[4].href, "http://example.com/bookmark/short")
-      assert.equal(annotation.document.link[5].href, "doi:10.1175/JCLI-D-11-00015.1")
-      assert.match(annotation.document.link[6].href, /.+foo\.pdf$/)
-      assert.equal(annotation.document.link[6].type, "application/pdf")
-      assert.equal(annotation.document.link[7].href, "doi:10.1175/JCLI-D-11-00015.1")
+      assert.equal(annotation.document.link[5].rel, "canonical")
+      assert.equal(annotation.document.link[5].href, "http://example.com/canonical")
+      assert.equal(annotation.document.link[6].href, "doi:10.1175/JCLI-D-11-00015.1")
+      assert.match(annotation.document.link[7].href, /.+foo\.pdf$/)
+      assert.equal(annotation.document.link[7].type, "application/pdf")
+      assert.equal(annotation.document.link[8].href, "doi:10.1175/JCLI-D-11-00015.1")
 
     it 'should ignore atom and RSS feeds and alternate languages', ->
-      assert.equal(annotation.document.link.length, 8)
+      assert.equal(annotation.document.link.length, 9)
 
     it 'should have highwire metadata', ->
       assert.ok(annotation.document.highwire)
@@ -102,7 +105,11 @@ describe 'Annotator.Plugin.Document', ->
     
     it 'should have unique uris', ->
       uris = annotator.plugins.Document.uris()
-      assert.equal(uris.length, 6)
+      assert.equal(uris.length, 7)
+
+    it 'uri() returns the canonical uri', ->
+      uri = annotator.plugins.Document.uri()
+      assert.equal(uri, annotation.document.link[5].href)
 
     it 'should have a favicon', ->
       assert.equal(


### PR DESCRIPTION
Search in metadata.link for canonical uri.

It tried to look for links in the metadata property which is trivially wrong.