### PR TITLE
Fix for duplicated editor control buttons

### DIFF
--- a/src/ui/editor.js
+++ b/src/ui/editor.js
@@ -451,7 +451,7 @@ var Editor = exports.Editor = Widget.extend({
     checkOrientation: function () {
         Widget.prototype.checkOrientation.call(this);
 
-        var list = this.element.find('ul'),
+        var list = this.element.find('ul').first(),
             controls = this.element.find('.annotator-controls');
 
         if (this.element.hasClass(this.classes.invert.y)) {


### PR DESCRIPTION
I'm working on integrating [meltdown](https://github.com/iphands/Meltdown) with annotator and found a weird error where the control buttons would get duplicated on reloads after the meltdown editor was initialized.  Screenshot of the duplicated controls attached since it's a bit difficult to describe (and the error was actually compounded and became much worse on subsequent loads).

![annotator-duplicated-controls](https://cloud.githubusercontent.com/assets/691231/7662168/6cc38be0-fb27-11e4-940e-c4e25d914fcc.png)

I've made an adjustment so that annotator controls are only added after the *first* ul, not every ul element inside the annotation editor widget, and it resolves the problem.