### PR TITLE
Add confirmation for deleting an annotation

### DIFF
--- a/src/ui/viewer.js
+++ b/src/ui/viewer.js
@@ -1,3 +1,4 @@
+/* global window */
 "use strict";
 
 var Widget = require('./widget').Widget,
@@ -337,11 +338,13 @@ var Viewer = exports.Viewer = Widget.extend({
     //
     // Returns nothing.
     _onDeleteClick: function (event) {
-        var item = $(event.target)
-            .parents('.annotator-annotation')
-            .data('annotation');
-        this.hide();
-        this.options.onDelete(item);
+        if (window.confirm(_t('Delete this annotation?'))) {
+            var item = $(event.target)
+                .parents('.annotator-annotation')
+                .data('annotation');
+            this.hide();
+            this.options.onDelete(item);
+        }
     },
 
     // Event callback: called when a user triggers `mouseover` on a highlight

--- a/test/spec/ui/viewer_spec.js
+++ b/test/spec/ui/viewer_spec.js
@@ -196,7 +196,8 @@ describe('ui.viewer.Viewer', function () {
     });
 
     describe('when the permitDelete function returns true', function () {
-        var onDelete = null;
+        var onDelete = null,
+            sandbox = null;
 
         beforeEach(function () {
             onDelete = sinon.stub();
@@ -205,9 +206,11 @@ describe('ui.viewer.Viewer', function () {
                 onDelete: onDelete
             });
             v.attach();
+            sandbox = sinon.sandbox.create();
         });
 
         afterEach(function () {
+            sandbox.restore();
             v.destroy();
         });
 
@@ -227,13 +230,24 @@ describe('ui.viewer.Viewer', function () {
             assert.property(callArgs[2], 'hideDelete');
         });
 
-        it('clicking on the delete button should trigger an annotation delete', function () {
+        it('clicking on the delete button and confirming should trigger an annotation delete', function () {
             var ann = {
                 text: "Rabbits with cloaks"
             };
             v.load([ann]);
+            sandbox.stub(window, 'confirm').returns(true);
             v.element.find('.annotator-delete').click();
             sinon.assert.calledWith(onDelete, ann);
+        });
+
+        it('clicking on the delete button without confirming shouldn\'t trigger an annotation delete', function () {
+            var ann = {
+                text: "Rabbits with cloaks"
+            };
+            v.load([ann]);
+            sandbox.stub(window, 'confirm').returns(false);
+            v.element.find('.annotator-delete').click();
+            sinon.assert.neverCalledWith(onDelete, ann);
         });
     });
 


### PR DESCRIPTION
It's possible for users to assume that the 'x' on the annotator
widget is for closing the window instead of deleting the annotation.

This adds a reminder that they are about to delete their annotation.

Maybe this could be configurable, and off by default? Anyways, if
you don't think this belongs in annotator.js, feel free to reject..
this is just an idea.