### PR TITLE
issue #565 highlight during annotation

### DIFF
--- a/src/ui/highlighter.js
+++ b/src/ui/highlighter.js
@@ -48,6 +48,7 @@ function reanchorRange(range, rootElement) {
     try {
         return xpathRange.Range.sniff(range).normalize(rootElement);
     } catch (e) {
+    	console.error(e);
         if (!(e instanceof xpathRange.Range.RangeError)) {
             // Oh Javascript, why you so crap? This will lose the traceback.
             throw(e);

--- a/src/ui/main.js
+++ b/src/ui/main.js
@@ -292,7 +292,8 @@ function main(options) {
         },
 
         annotationsLoaded: function (anns) { s.highlighter.drawAll(anns); },
-        annotationCreated: function (ann) { s.highlighter.draw(ann); },
+        // update to highlight during annotation
+        annotationCreated: function (ann) { /* s.highlighter.draw(ann);*/ },
         annotationDeleted: function (ann) { s.highlighter.undraw(ann); },
         annotationUpdated: function (ann) { s.highlighter.redraw(ann); },
 
@@ -301,7 +302,17 @@ function main(options) {
             // completes, and rejected if editing is cancelled. We return it
             // here to "stall" the annotation process until the editing is
             // done.
-            return s.editor.load(annotation, s.interactionPoint);
+
+        	// highlight during annotaiton
+	        s.highlighter.draw(annotation);
+	        
+	        return s.editor.load(annotation, s.interactionPoint)
+	        .catch( function (object) {
+	        	// remove highlighting for cancelled annotation
+	        	s.highlighter.undraw(annotation);
+	        	throw object;
+	        });
+            
         },
 
         beforeAnnotationUpdated: function (annotation) {

--- a/src/ui/widget.js
+++ b/src/ui/widget.js
@@ -83,6 +83,7 @@ Widget.prototype.isShown = function () {
     return !$(this.element).hasClass(this.classes.hide);
 };
 
+/*
 Widget.prototype.checkOrientation = function () {
     this.resetOrientation();
 
@@ -108,6 +109,51 @@ Widget.prototype.checkOrientation = function () {
 
     return this;
 };
+*/
+
+Widget.prototype.checkOrientation = function () {
+    this.resetOrientation();
+
+    var $win = $(global),
+        $widget = this.element.children(":first"),
+        offset = $widget.offset(),
+        viewport = {
+            top: $win.scrollTop(),
+            right: $win.width() + $win.scrollLeft(),
+            left:$win.scrollLeft(),
+            width: $win.width(),
+    		centre: $win.scrollLeft() + ($win.width()/2)
+        },
+        current = {
+            top: offset.top,
+            right: offset.left + $widget.width(),
+            left: offset.left,
+            width: $widget.width()
+        };
+
+    if (viewport.top > current.top) {
+        this.invertY();
+    }
+
+    // does widget right bound go beyond right edge of viewport?
+    if (current.right > viewport.right) {
+    	// is widget left offset > widget width 
+    	if (current.left > current.width) {
+    		this.invertX();
+    	} else {
+    		// no room to invert, so centre
+    		$widget.offset({top: $widget.offset.top, left: (viewport.centre - (current.width/2))});
+    		console.log('no room to invert, so centring');
+    	}
+    }
+    
+    if (current.left < window.left) {
+    	console.log('truncated before inversion?');
+    }
+
+    return this;
+};
+
 
 // Public: Resets orientation of widget on the X & Y axis.
 //


### PR DESCRIPTION
The following updated highlights selected text during annotation instead of just before and after.
A solution to issue #565 