### PR TITLE
Adding hook for setting identity in SimpleIdentityPolicy

### DIFF
--- a/src/identity.js
+++ b/src/identity.js
@@ -18,6 +18,9 @@ exports.simple = function simple() {
     return {
         configure: function (registry) {
             registry.registerUtility(identity, 'identityPolicy');
+        },
+        beforeAnnotationCreated: function (annotation) {
+            annotation.user = identity.identity;
         }
     };
 };


### PR DESCRIPTION
Modified identity.js so it sets the user before an annotation is created.