### PR TITLE
point to new project location at https://annotator.apache.org/

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,6 +5,8 @@ Annotator
 
 |Build Matrix|
 
+This project is no longer maintained here: it has moved to https://annotator.apache.org/ .
+
 Annotator is a JavaScript library for building annotation applications in
 browsers. It provides a set of interoperable tools for annotating content in
 webpages. For a simple demonstration, visit the `Annotator home page`_ or


### PR DESCRIPTION
Hi!

I have a suspicion that this repo is succeeded by https://annotator.apache.org/ . 

If so, suggest to include this in the readme . 

thx,
-jorrit